### PR TITLE
HGA-1513: Add in wait_for_build function

### DIFF
--- a/circleci-utils
+++ b/circleci-utils
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Import utils
+. ./hg-circle-scripts/utils
+
+wait_for_build() {
+    CIRCLE_API_TOKEN=$1
+    BUILD_URL=$2
+    TIMEOUT_IN_SECS=$3
+    POLL_INTERVAL_IN_SECS=15
+
+    # Pipe syserr message to /dev/null, we don't care we're not trying to change the system date.
+    # Use cat to suppress exit code.
+    timeout_time=$(date -s "${TIMEOUT_IN_SECS} seconds" +%s 2> /dev/null | cat)
+    for i in `seq 1 $(($TIMEOUT_IN_SECS / $POLL_INTERVAL_IN_SECS))`; do
+        log "[Try ${i}] Waiting for build: $BUILD_URL"
+
+        result=$(curl --user ${CIRCLE_API_TOKEN}: \
+            -sS --fail \
+            $BUILD_URL)
+        lifecycle=$(echo $result | $JQ '.lifecycle')
+        if [ $lifecycle == 'finished' ]; then
+            # We've got to a final state, eg. success, failed, canceled etc.
+            log "Breaking out because the job finished"
+            break
+        fi
+
+        if [ $(date +%s) -gt $timeout_time ]; then
+            # We've hit a roadblock, let's get out of here and not tie things up any longer.
+            log "Exiting.. Job timed out."
+            exit 1
+        fi
+        
+        sleep $POLL_INTERVAL_IN_SECS
+    done
+}


### PR DESCRIPTION
This is needed to wait for a CircleCI build created via the API to be completed before continuing with the remainder of the build.