### PR TITLE
Upload info file

### DIFF
--- a/ui-deploy
+++ b/ui-deploy
@@ -51,11 +51,22 @@ aws s3 sync build/ "s3://${s3_path}/${current_branch}" \
   --region $region \
   --exclude "*.map" \
   --exclude "*index.html" \
+  --exclude "*info.json" \
   --cache-control "max-age=31536000,public"
 
 # Upload index.html with no-cache policies
 log "Uploading index.html"
 aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
+  --region $region \
+  --metadata-directive REPLACE \
+  --cache-control max-age=0,no-cache,no-store,must-revalidate \
+  --content-type text/html \
+  --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
+  --acl public-read
+
+# Upload info.json with no-cache policies
+log "Uploading static/info.json"
+aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/static/info.json" \
   --region $region \
   --metadata-directive REPLACE \
   --cache-control max-age=0,no-cache,no-store,must-revalidate \

--- a/ui-deploy
+++ b/ui-deploy
@@ -64,12 +64,16 @@ aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
   --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
   --acl public-read
 
-# Upload info.json with no-cache policies
 log "Uploading static/info.json"
-aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/static/info.json" \
-  --region $region \
-  --metadata-directive REPLACE \
-  --cache-control max-age=0,no-cache,no-store,must-revalidate \
-  --content-type text/html \
-  --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
-  --acl public-read
+if [[ -f "build/static/info.json" ]]; then
+    # Upload info.json with no-cache policies
+    aws s3 cp build/static/info.json "s3://${s3_path}/${current_branch}/static/info.json" \
+    --region $region \
+    --metadata-directive REPLACE \
+    --cache-control max-age=0,no-cache,no-store,must-revalidate \
+    --content-type text/html \
+    --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
+    --acl public-read
+else
+    log "static/info.json was not found"
+fi


### PR DESCRIPTION
When deploying the UI, upload the file that contains the app version with no browser caching. We want new versions to be available as soon as a new version is deployed.