### PR TITLE
Aneto/hga 1149 change cdn caching policy

### DIFF
--- a/ui-deploy
+++ b/ui-deploy
@@ -64,7 +64,6 @@ aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
   --metadata-directive REPLACE \
   --cache-Control: max-age=0,s-maxage=31556952,must-revalidate \
   --content-type text/html \
-  --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
   --acl public-read
 
 log "Uploading static/info.json"

--- a/ui-deploy
+++ b/ui-deploy
@@ -62,7 +62,7 @@ log "Uploading index.html"
 aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
   --region $region \
   --metadata-directive REPLACE \
-  --cache-control max-age=0,no-cache,no-store,must-revalidate \
+  --cache-Control: max-age=0,s-maxage=31556952,must-revalidate \
   --content-type text/html \
   --expires "Sat, 01 Jan 2000 00:00:00 GMT" \
   --acl public-read

--- a/ui-deploy
+++ b/ui-deploy
@@ -62,7 +62,7 @@ log "Uploading index.html"
 aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
   --region $region \
   --metadata-directive REPLACE \
-  --cache-Control: max-age=0,s-maxage=31556952,must-revalidate \
+  --cache-control: max-age=0,s-maxage=31556952,must-revalidate \
   --content-type text/html \
   --acl public-read
 


### PR DESCRIPTION
cache-control: max-age=0,s-maxage=31556952,must-revalidateheader.
- **max-age**: controls how long a page gets cached. max-age=0 tells browsers and CDNs to download the page from the server the next time they need it
- **s-maxage**: [controls how long the response is cached by the CDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#expiration). It takes precedence over max-age in CDNs and is ignored by browsers. s-maxage=<large value> tells the CDN that it can cache the page for a while
- **must-revalidate**: ensures the browser will re-fetch the page in some edge cases where it typically wouldn’t (eg when pressing “Back” or “Forward”)


**expires** flag removed
It’s [ignored ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires) when Cache-Control: max-age=... is present, and it doesn’t have any effect with Cache-Control: no-cache either.