### PR TITLE
fix: typo unnecessary ':' after cache-control

### DIFF
--- a/ui-deploy
+++ b/ui-deploy
@@ -62,7 +62,7 @@ log "Uploading index.html"
 aws s3 cp build/index.html "s3://${s3_path}/${current_branch}/index.html" \
   --region $region \
   --metadata-directive REPLACE \
-  --cache-control: max-age=0,s-maxage=31556952,must-revalidate \
+  --cache-control max-age=0,s-maxage=31556952,must-revalidate \
   --content-type text/html \
   --acl public-read
 


### PR DESCRIPTION
Removed unnecessary ':' after --cache-control that raised the error:

`...
Unknown options: --cache-control:,max-age=0,s-maxage=31556952,must-revalidate
...`

resolves HGA-1149